### PR TITLE
Fixes status update issue for admin revoke API

### DIFF
--- a/components/com.wso2.openbanking.berlin.consent.extensions/src/main/java/com/wso2/openbanking/berlin/consent/extensions/admin/impl/BGConsentAdminHandler.java
+++ b/components/com.wso2.openbanking.berlin.consent.extensions/src/main/java/com/wso2/openbanking/berlin/consent/extensions/admin/impl/BGConsentAdminHandler.java
@@ -67,9 +67,9 @@ public class BGConsentAdminHandler extends DefaultConsentAdminHandler {
             DetailedConsentResource consentResource = coreService.getDetailedConsent(consentId);
 
             // Validate non customer-care user is revoking only their own consents
-            if (consentAdminData.getQueryParams().containsKey("userId")) {
+            if (consentAdminData.getQueryParams().containsKey("userID")) {
                 List<AuthorizationResource> filteredIds = consentResource.getAuthorizationResources().stream()
-                        .filter(authorizationResource -> consentAdminData.getQueryParams().get("userId").toString()
+                        .filter(authorizationResource -> consentAdminData.getQueryParams().get("userID").toString()
                                 .contains(authorizationResource.getUserID()))
                         .collect(Collectors.toList());
                 if (filteredIds.isEmpty()) {
@@ -126,7 +126,7 @@ public class BGConsentAdminHandler extends DefaultConsentAdminHandler {
 
         try {
 
-            if (!consentAdminData.getQueryParams().containsKey("userId")) {
+            if (!consentAdminData.getQueryParams().containsKey("userID")) {
                 coreService.revokeConsent(consentResource.getConsentID(),
                         ConsentStatusEnum.TERMINATED_BY_TPP.toString());
             } else {

--- a/components/com.wso2.openbanking.berlin.consent.extensions/src/test/java/com/wso2/openbanking/berlin/consent/extensions/admin/impl/BGConsentAdminHandlerTest.java
+++ b/components/com.wso2.openbanking.berlin.consent.extensions/src/test/java/com/wso2/openbanking/berlin/consent/extensions/admin/impl/BGConsentAdminHandlerTest.java
@@ -92,7 +92,7 @@ public class BGConsentAdminHandlerTest extends PowerMockTestCase {
         List<String> consentIDList = new ArrayList<>();
         consentIDList.add(consentId);
         queryParams.put("consentID", consentIDList);
-        queryParams.put("userId", "ann@wso2.com");
+        queryParams.put("userID", "ann@wso2.com");
 
         doReturn(queryParams).when(consentAdminDataMock).getQueryParams();
         doReturn(getAccountConsentResource("valid")).when(consentCoreServiceMock)
@@ -193,7 +193,7 @@ public class BGConsentAdminHandlerTest extends PowerMockTestCase {
         List<String> consentIDList = new ArrayList<>();
         consentIDList.add(consentId);
         queryParams.put("consentID", consentIDList);
-        queryParams.put("userId", "admin@wso2.com");
+        queryParams.put("userID", "admin@wso2.com");
 
         DetailedConsentResource accountConsentResource = getAccountConsentResource("valid");
 


### PR DESCRIPTION
## Fixes status update issue for admin revoke API

> This PR fixes issue of not updating the consent status to "revokedByPsu" when admin revoke API is invoked with userID query param

**Issue link:** *https://github.com/wso2-enterprise/wso2-ob-internal/issues/801*

**Doc Issue:** **

**Applicable Labels:** *OB 3.0.0, Berlin Toolkit*

------

### Development Checklist

1. [ ] Build complete solution with pull request in place.
2. [ ] Ran checkstyle plugin with pull request in place.
3. [ ] Ran Findbugs plugin with pull request in place.
4. [ ] Ran FindSecurityBugs plugin and verified report.
5. [ ] Formatted code according to WSO2 code style.
6. [ ] Have you verified the PR doesn't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [ ] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Verified tests in multiple database environments (if applicable).
3. [ ] Tested with BI enabled  (if applicable).
