### PR TITLE
Fix the idempotency issue in explicit auth requests

### DIFF
--- a/components/org.wso2.openbanking.berlin.consent.extensions/src/main/java/org/wso2/openbanking/berlin/consent/extensions/manage/handler/request/impl/ExplicitAuthRequestHandler.java
+++ b/components/org.wso2.openbanking.berlin.consent.extensions/src/main/java/org/wso2/openbanking/berlin/consent/extensions/manage/handler/request/impl/ExplicitAuthRequestHandler.java
@@ -226,21 +226,24 @@ public class ExplicitAuthRequestHandler implements RequestHandler {
 
         } else {
             Map<String, String> attributesToStore = new HashMap<>();
+            String requestId = consentManageData.getHeaders().get(ConsentExtensionConstants.X_REQUEST_ID_HEADER);
             if (StringUtils.equals(AuthTypeEnum.CANCELLATION.toString(), authType)) {
-                String xRequestIdKey = CommonConsentUtil.constructAttributeKey(
-                        consentManageData.getRequestPath(), ConsentExtensionConstants.AUTH_CANCEL_X_REQUEST_ID);
-                attributesToStore.put(xRequestIdKey, consentManageData.getHeaders()
-                        .get(ConsentExtensionConstants.X_REQUEST_ID_HEADER));
+                String xRequestIdKey =  CommonConsentUtil.constructAttributeKey(
+                        consentManageData.getRequestPath(), ConsentExtensionConstants.AUTH_CANCEL_X_REQUEST_ID,
+                        requestId);
+                attributesToStore.put(xRequestIdKey, requestId);
                 String createdTimeKey = CommonConsentUtil.constructAttributeKey(
-                        consentManageData.getRequestPath(), ConsentExtensionConstants.AUTH_CANCEL_CREATED_TIME);
+                        consentManageData.getRequestPath(), ConsentExtensionConstants.AUTH_CANCEL_CREATED_TIME,
+                        requestId);
                 attributesToStore.put(createdTimeKey, String.valueOf(OffsetDateTime.now().toEpochSecond()));
             } else {
                 String xRequestIdKey = CommonConsentUtil.constructAttributeKey(
-                        consentManageData.getRequestPath(), ConsentExtensionConstants.EXPLICIT_AUTH_X_REQUEST_ID);
-                attributesToStore.put(xRequestIdKey, consentManageData.getHeaders()
-                        .get(ConsentExtensionConstants.X_REQUEST_ID_HEADER));
+                        consentManageData.getRequestPath(), ConsentExtensionConstants.EXPLICIT_AUTH_X_REQUEST_ID,
+                        requestId);
+                attributesToStore.put(xRequestIdKey, requestId);
                 String createdTimeKey = CommonConsentUtil.constructAttributeKey(
-                        consentManageData.getRequestPath(), ConsentExtensionConstants.EXPLICIT_AUTH_CREATED_TIME);
+                        consentManageData.getRequestPath(), ConsentExtensionConstants.EXPLICIT_AUTH_CREATED_TIME,
+                        requestId);
                 attributesToStore.put(createdTimeKey, String.valueOf(OffsetDateTime.now().toEpochSecond()));
             }
 
@@ -288,6 +291,7 @@ public class ExplicitAuthRequestHandler implements RequestHandler {
                                                                 Map<String, Object> scaInfoMap) {
 
         Map<String, String> consentAttributesMap = new HashMap<>();
+        String requestId = consentManageData.getHeaders().get(ConsentExtensionConstants.X_REQUEST_ID_HEADER);
 
         String authId = createdAuthorizationResource.getAuthorizationID();
         ScaApproach scaApproach = (ScaApproach) scaInfoMap.get(CommonConstants.SCA_APPROACH_KEY);
@@ -306,19 +310,20 @@ public class ExplicitAuthRequestHandler implements RequestHandler {
         if (StringUtils.contains(consentManageData.getRequestPath(),
                 ConsentExtensionConstants.PAYMENT_EXPLICIT_CANCELLATION_AUTHORISATION_PATH_END)) {
             String xRequestIdKey = CommonConsentUtil.constructAttributeKey(
-                    consentManageData.getRequestPath(), ConsentExtensionConstants.AUTH_CANCEL_X_REQUEST_ID);
-            consentAttributesMap.put(xRequestIdKey, consentManageData.getHeaders()
-                    .get(ConsentExtensionConstants.X_REQUEST_ID_HEADER));
+                    consentManageData.getRequestPath(), ConsentExtensionConstants.AUTH_CANCEL_X_REQUEST_ID,
+                    requestId);
+            consentAttributesMap.put(xRequestIdKey, requestId);
             String createdTimeKey = CommonConsentUtil.constructAttributeKey(
-                    consentManageData.getRequestPath(), ConsentExtensionConstants.AUTH_CANCEL_CREATED_TIME);
+                    consentManageData.getRequestPath(), ConsentExtensionConstants.AUTH_CANCEL_CREATED_TIME, requestId);
             consentAttributesMap.put(createdTimeKey, String.valueOf(OffsetDateTime.now().toEpochSecond()));
         } else {
             String xRequestIdKey = CommonConsentUtil.constructAttributeKey(
-                    consentManageData.getRequestPath(), ConsentExtensionConstants.EXPLICIT_AUTH_X_REQUEST_ID);
-            consentAttributesMap.put(xRequestIdKey, consentManageData.getHeaders()
-                    .get(ConsentExtensionConstants.X_REQUEST_ID_HEADER));
+                    consentManageData.getRequestPath(), ConsentExtensionConstants.EXPLICIT_AUTH_X_REQUEST_ID,
+                    requestId);
+            consentAttributesMap.put(xRequestIdKey, requestId);
             String createdTimeKey = CommonConsentUtil.constructAttributeKey(
-                    consentManageData.getRequestPath(), ConsentExtensionConstants.EXPLICIT_AUTH_CREATED_TIME);
+                    consentManageData.getRequestPath(), ConsentExtensionConstants.EXPLICIT_AUTH_CREATED_TIME,
+                    requestId);
             consentAttributesMap.put(createdTimeKey, String.valueOf(OffsetDateTime.now().toEpochSecond()));
         }
 

--- a/components/org.wso2.openbanking.berlin.consent.extensions/src/main/java/org/wso2/openbanking/berlin/consent/extensions/manage/util/BerlinIdempotencyValidator.java
+++ b/components/org.wso2.openbanking.berlin.consent.extensions/src/main/java/org/wso2/openbanking/berlin/consent/extensions/manage/util/BerlinIdempotencyValidator.java
@@ -18,10 +18,14 @@
 
 package org.wso2.openbanking.berlin.consent.extensions.manage.util;
 
+import com.wso2.openbanking.accelerator.common.config.OpenBankingConfigParser;
 import com.wso2.openbanking.accelerator.common.exception.ConsentManagementException;
 import com.wso2.openbanking.accelerator.common.util.Generated;
 import com.wso2.openbanking.accelerator.consent.extensions.common.idempotency.IdempotencyConstants;
+import com.wso2.openbanking.accelerator.consent.extensions.common.idempotency.IdempotencyValidationException;
+import com.wso2.openbanking.accelerator.consent.extensions.common.idempotency.IdempotencyValidationResult;
 import com.wso2.openbanking.accelerator.consent.extensions.common.idempotency.IdempotencyValidator;
+import com.wso2.openbanking.accelerator.consent.extensions.manage.model.ConsentManageData;
 import com.wso2.openbanking.accelerator.consent.mgt.dao.models.DetailedConsentResource;
 import com.wso2.openbanking.accelerator.consent.mgt.service.impl.ConsentCoreServiceImpl;
 import net.minidev.json.JSONObject;
@@ -30,12 +34,68 @@ import org.apache.commons.logging.LogFactory;
 import org.wso2.openbanking.berlin.consent.extensions.common.ConsentExtensionConstants;
 import org.wso2.openbanking.berlin.consent.extensions.common.ConsentExtensionUtil;
 
+import java.io.IOException;
+import java.util.Map;
+
 /**
  * Class to handle idempotency related operations.
  */
 public class BerlinIdempotencyValidator extends IdempotencyValidator {
 
     private static final Log log = LogFactory.getLog(BerlinIdempotencyValidator.class);
+
+
+
+    @Override
+    public IdempotencyValidationResult validateIdempotency(ConsentManageData consentManageData)
+            throws IdempotencyValidationException {
+
+        if (!OpenBankingConfigParser.getInstance().isIdempotencyValidationEnabled()) {
+            return new IdempotencyValidationResult(false, false);
+        }
+
+        String requestPath = consentManageData.getRequestPath();
+
+        if (requestPath.contains(ConsentExtensionConstants.EXPLICIT_AUTHORISATION_PATH_END)
+                || requestPath.contains(ConsentExtensionConstants
+                .PAYMENT_EXPLICIT_CANCELLATION_AUTHORISATION_PATH_END)) {
+
+            if (isPreIdempotencyValidationsFail(consentManageData)) {
+                return new IdempotencyValidationResult(false, false);
+            }
+
+            String idempotencyKeyValue = consentManageData.getHeaders().get(getIdempotencyHeaderName());
+            String idempotencyKeyName = CommonConsentUtil
+                    .constructAttributeKey(getIdempotencyAttributeName(requestPath), idempotencyKeyValue);
+
+            if (IdempotencyConstants.EMPTY_OBJECT.equals(consentManageData.getPayload().toString())) {
+                try {
+                    // Start authorisation and cancellation authorisation requests do not contain a payload.
+                    IdempotencyValidationResult result = validateIdempotencyWithoutPayload(consentManageData,
+                            idempotencyKeyName, idempotencyKeyValue);
+                    if (!result.isIdempotent()) {
+                        return result;
+                    }
+                    // Creating unique idempotency and creation time attributes.
+                    String uniqueAttributeName = getUniqueCreatedTimeAttributeNameForExplicitRequest(requestPath,
+                            idempotencyKeyValue);
+                    long createdTime = getCreatedTimeFromConsentAttributes(result.getConsent(), uniqueAttributeName);
+                    return validateIdempotencyConditions(consentManageData, result.getConsent(), createdTime);
+                } catch (IOException e) {
+                    log.error(IdempotencyConstants.JSON_COMPARING_ERROR, e);
+                    throw new IdempotencyValidationException(IdempotencyConstants.JSON_COMPARING_ERROR);
+                } catch (ConsentManagementException e) {
+                    log.error(IdempotencyConstants.CONSENT_RETRIEVAL_ERROR, e);
+                    return new IdempotencyValidationResult(true, false);
+                }
+            }
+            return new IdempotencyValidationResult(false, false);
+        } else {
+            return super.validateIdempotency(consentManageData);
+        }
+    }
+
+
 
     /**
      * Method to get the Idempotency Key Name store in consent Attributes.
@@ -96,6 +156,49 @@ public class BerlinIdempotencyValidator extends IdempotencyValidator {
         } else {
             return consentRequest.getCreatedTime();
         }
+    }
+
+    @Override
+    protected void checkSameConsentIdRelatedToDifferentRequestId(ConsentManageData consentManageData,
+                                                                 Map.Entry<String, String> entry,
+                                                                 String idempotencyKeyValue)
+            throws IdempotencyValidationException {
+
+        String requestPath = consentManageData.getRequestPath();
+        if (!(requestPath.contains(ConsentExtensionConstants.EXPLICIT_AUTHORISATION_PATH_END)
+                || requestPath.contains(ConsentExtensionConstants
+                .PAYMENT_EXPLICIT_CANCELLATION_AUTHORISATION_PATH_END))) {
+
+            /* The NextGenPSD2 specification requires creating multiple authorisation resources for the same
+               consent. Therefore, not performing this check for explicit authorisation/cancellation requests. */
+            super.checkSameConsentIdRelatedToDifferentRequestId(consentManageData, entry, idempotencyKeyValue);
+        }
+    }
+
+    /**
+     * Returns the attribute name for the explicit authorisation request.
+     *
+     * The format of the attribute name would be in this format: resourcePath_parameterName_requestId
+     *
+     * @param resourcePath path of the request
+     * @param requestId request ID
+     * @return the unique attribute name for the current explicit request type
+     */
+    private String getUniqueCreatedTimeAttributeNameForExplicitRequest(String resourcePath, String requestId) {
+
+        String path = ConsentExtensionUtil.getServiceDifferentiatingRequestPath(resourcePath);
+        String attributeKey;
+
+        if (ConsentExtensionConstants.PAYMENT_EXPLICIT_CANCELLATION_AUTHORISATION_PATH_END.equals(path)) {
+            attributeKey = CommonConsentUtil.constructAttributeKey(resourcePath,
+                    ConsentExtensionConstants.AUTH_CANCEL_CREATED_TIME, requestId);
+            return attributeKey;
+        } else if (ConsentExtensionConstants.EXPLICIT_AUTHORISATION_PATH_END.equals(path)) {
+            attributeKey = CommonConsentUtil.constructAttributeKey(resourcePath,
+                    ConsentExtensionConstants.EXPLICIT_AUTH_CREATED_TIME, requestId);
+            return attributeKey;
+        }
+        return null;
     }
 
     /**

--- a/components/org.wso2.openbanking.berlin.consent.extensions/src/main/java/org/wso2/openbanking/berlin/consent/extensions/manage/util/CommonConsentUtil.java
+++ b/components/org.wso2.openbanking.berlin.consent.extensions/src/main/java/org/wso2/openbanking/berlin/consent/extensions/manage/util/CommonConsentUtil.java
@@ -363,14 +363,15 @@ public class CommonConsentUtil {
     }
 
     /**
-     * Method to construct the attribute key to store parameters as a consent attribute. It will be constructed as
-     * requestPath_param.
-     * @param requestPath     Request path
-     * @param param           Parameter name
-     * @return  constructed attribute key
+     * This method accepts a number of strings as arguments and outputs them according to the provided order
+     * joined with underscore characters.
+     *
+     * @param strings a number of strings
+     * @return joined strings using underscores
      */
-    public static String constructAttributeKey(String requestPath, String param) {
-        return StringUtils.join(requestPath, "_", param);
+    public static String constructAttributeKey(String... strings) {
+
+        return StringUtils.join(strings, "_");
     }
 
     /**

--- a/open-banking-test-suite/toolkit-berlin-test/com.wso2.openbanking.toolkit.berlin.test/berlin.common.utils/src/main/groovy/com/wso2/openbanking/berlin/common/utils/BerlinRequestBuilder.groovy
+++ b/open-banking-test-suite/toolkit-berlin-test/com.wso2.openbanking.toolkit.berlin.test/berlin.common.utils/src/main/groovy/com/wso2/openbanking/berlin/common/utils/BerlinRequestBuilder.groovy
@@ -208,25 +208,15 @@ class BerlinRequestBuilder {
     static Response getRefreshTokenGrantAccessToken(refreshToken, BerlinConstants.SCOPES scopes) {
 
         def config = ConfigParser.getInstance()
-        Scope scopeList = null
-
-        if(scopes != null) {
-            String scopeArr = String.join(" ", scopes.getScopes())
-            scopeList = new Scope(scopeArr)
-        }
 
         RefreshToken refreshTokenValue = new RefreshToken(refreshToken)
         AuthorizationGrant refreshTokenGrant = new RefreshTokenGrant(refreshTokenValue)
 
         ClientID clientID = new ClientID(AppConfigReader.getClientId())
 
-        String assertionString = new AccessTokenJwtDto().getJwt(clientID.toString())
-
-        ClientAuthentication clientAuth = new PrivateKeyJWT(SignedJWT.parse(assertionString))
-
         URI tokenEndpoint = new URI("${config.getAuthorisationServerURL()}/oauth2/token")
 
-        TokenRequest request = new TokenRequest(tokenEndpoint, clientAuth, refreshTokenGrant, scopeList)
+        TokenRequest request = new TokenRequest(tokenEndpoint, clientID, refreshTokenGrant)
 
         HTTPRequest httpRequest = request.toHTTPRequest()
 

--- a/open-banking-test-suite/toolkit-berlin-test/com.wso2.openbanking.toolkit.berlin.test/integration.tests/accounts/src/test/groovy/com.wso2.openbanking.toolkit.berlin.integration.test.accounts/common_test/Accounts_Authorization_Tests/AccountsExplicitAuthorisation.groovy
+++ b/open-banking-test-suite/toolkit-berlin-test/com.wso2.openbanking.toolkit.berlin.test/integration.tests/accounts/src/test/groovy/com.wso2.openbanking.toolkit.berlin.integration.test.accounts/common_test/Accounts_Authorization_Tests/AccountsExplicitAuthorisation.groovy
@@ -160,7 +160,7 @@ class AccountsExplicitAuthorisation extends AbstractAccountsFlow{
 
         //Consent Initiation
         doExplicitAuthInitiation(consentPath, initiationPayload)
-        Assert.assertEquals(consentResponse.statusCode(), BerlinConstants.STATUS_CODE_201)
+        Assert.assertEquals(authorisationResponse.statusCode(), BerlinConstants.STATUS_CODE_201)
         Assert.assertNotNull(accountId)
 
         //Create Explicit Authorisation Resources
@@ -413,11 +413,6 @@ class AccountsExplicitAuthorisation extends AbstractAccountsFlow{
                 .body("{}")
                 .post("${consentPath}/${accountId}/authorisations")
 
-        Assert.assertEquals(authorisationResponse2.getStatusCode(), BerlinConstants.STATUS_CODE_400)
-        Assert.assertEquals(TestUtil.parseResponseBody(authorisationResponse2, BerlinConstants.TPPMESSAGE_CODE),
-                BerlinConstants.FORMAT_ERROR)
-        Assert.assertTrue (TestUtil.parseResponseBody (authorisationResponse2, BerlinConstants.TPPMESSAGE_TEXT).
-                contains ("Cannot use different unique identifier for the same consent ID when the request does not " +
-                        "contain a payload."))
+        Assert.assertEquals(authorisationResponse2.getStatusCode(), BerlinConstants.STATUS_CODE_201)
     }
 }

--- a/open-banking-test-suite/toolkit-berlin-test/com.wso2.openbanking.toolkit.berlin.test/integration.tests/payments/src/test/groovy/com/wso2/openbanking/toolkit/berlin/integration/test/payments/common_test/Payments_Authorization_Tests/ExplicitAuthorisationTest.groovy
+++ b/open-banking-test-suite/toolkit-berlin-test/com.wso2.openbanking.toolkit.berlin.test/integration.tests/payments/src/test/groovy/com/wso2/openbanking/toolkit/berlin/integration/test/payments/common_test/Payments_Authorization_Tests/ExplicitAuthorisationTest.groovy
@@ -396,11 +396,6 @@ class ExplicitAuthorisationTest extends AbstractPaymentsFlow {
                 .body("{}")
                 .post("${consentPath}/${paymentId}/authorisations")
 
-        Assert.assertEquals(authorisationResponse2.getStatusCode(), BerlinConstants.STATUS_CODE_400)
-        Assert.assertEquals(TestUtil.parseResponseBody(authorisationResponse2, BerlinConstants.TPPMESSAGE_CODE),
-                BerlinConstants.FORMAT_ERROR)
-        Assert.assertTrue (TestUtil.parseResponseBody (authorisationResponse2, BerlinConstants.TPPMESSAGE_TEXT).
-                contains ("Cannot use different unique identifier for the same consent ID when the request does not " +
-                        "contain a payload."))
+        Assert.assertEquals(authorisationResponse2.getStatusCode(), BerlinConstants.STATUS_CODE_201)
     }
 }


### PR DESCRIPTION
## Fix the idempotency issue in explicit auth requests

- This fixes the issue of not able to create multiple authorisation resources for the same consent.

**Issue link:** *https://github.com/wso2/financial-services-accelerator/issues/309*

**Doc Issue:** -

**Applicable Labels:** NextGenPSD2

------

### Development Checklist

1. [x] Built complete solution with pull request in place.
2. [x] Ran checkstyle plugin with pull request in place.
3. [x] Ran Findbugs plugin with pull request in place.
4. [x] Ran FindSecurityBugs plugin and verified report.
5. [x] Formatted code according to WSO2 code style.
6. [x] Have you verify the PR does't commit any keys, passwords, tokens, usernames, or other secrets?
7. [ ] Migration scripts written (if applicable).
8. [x] Have you followed secure coding standards in [WSO2 Secure Engineering Guidelines](http://wso2.com/technical-reports/wso2-secure-engineering-guidelines)?

### Testing Checklist

1. [ ] Written unit tests.
2. [ ] Documented test scenarios(link available in guides).
3. [ ] Written automation tests (link available in guides).
4. [ ] Verified tests in multiple database environments (if applicable).
5. [ ] Verified tests in multiple deployed specifications (if applicable).
6. [ ] Tested with OBBI enabled  (if applicable).
7. [ ] Tested with specification regulatory conformance suites  (if applicable).

**Automation Test Details**

| Test Suite        | Test Script IDs   |
| ----------------- | ----------------- |
| Integration Suite | *TCXXXXX, TCXXXX* |

**Conformance Tests Details**

| Test Suite Name  | Test Suite Version | Scenarios  | Result   |
| ---------------- | ------------------ | ---------- | -------- |
| *Security Suite* | *VX.X*             | *Foo, Bar* | *Passed* |

## Resources

**Knowledge Base:** https://sites.google.com/wso2.com/open-banking/

**Guides:** https://sites.google.com/wso2.com/open-banking/developer-guides
